### PR TITLE
Add aws profile parameter

### DIFF
--- a/clear_lambda_storage.py
+++ b/clear_lambda_storage.py
@@ -35,6 +35,9 @@ def init_boto_client(client_name, region, args):
             aws_secret_access_key=args.token_secret,
             region_name=region
         )
+    elif args.profile:
+        session = boto3.session.Session(profile_name=args.profile)
+        boto_client = session.client(client_name, region_name=region)
     else:
         boto_client = boto3.client(client_name, region_name=region)
 
@@ -159,6 +162,15 @@ if __name__ == '__main__':
             'as well (default: from local configuration.'
         ),
         metavar='token-secret'
+    )
+    PARSER.add_argument(
+        '--profile',
+        type=str,
+        help=(
+            'AWS profile. Optional '
+            '(default: "default" from local configuration).'
+        ),
+        metavar='profile'
     )
 
     remove_old_lambda_versions(PARSER.parse_args())


### PR DESCRIPTION
Added the `--profile` to allow to use of profiles other than the default one to suit my use case.

I am purposely not having a default profile as I work in multiple environments and always added the `--profile some_aws_profile` to avoid executing commands in somewhere not intended.

And thanks for the tool, it helps me to save tons of space:
```
----------
Deleted 634 versions from 9 functions
Freed 1168 MBs
```