### PR TITLE
Allow clear-lambda-storage to be installed via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.pyc
 __pycache__
 .serverless
+build
+clear_lambda_storage.egg-info
+dist

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+import setuptools
+
+with open("README.rst", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="clear-lambda-storage",
+    version="1.0",
+    author="",
+    author_email="",
+    description="Clear Lambda code storage",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    url="https://github.com/epsagon/clear-lambda-storage",
+    py_modules=["clear_lambda_storage"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=2.7',
+)


### PR DESCRIPTION
How would you feel about adding support for installing via pip by creating a python wheel?

A project I work on that uses AWS Lambda has build up a large amount of function storage on Lambda, and we would use this during each deploy to remove older functions.

If so, here's a PR that adds the `setup.py`.  I've left author, and email blank, and version to 1.0.

Cheers.
