### PR TITLE
Fixed queue library import

### DIFF
--- a/clear_lambda_storage.py
+++ b/clear_lambda_storage.py
@@ -4,7 +4,10 @@ Removes old versions of Lambda functions.
 from __future__ import print_function
 import argparse
 import boto3
-import Queue as queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 from boto3.session import Session
 from botocore.exceptions import ClientError
 

--- a/clear_lambda_storage.py
+++ b/clear_lambda_storage.py
@@ -4,7 +4,7 @@ Removes old versions of Lambda functions.
 from __future__ import print_function
 import argparse
 import boto3
-import queue
+import Queue as queue
 from boto3.session import Session
 from botocore.exceptions import ClientError
 


### PR DESCRIPTION
The importing queue library no longer supports as queue. In the latest version, it is named as Queue.