### PR TITLE
Allow script to be directly executed as a module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=2.7',
+    entry_points={
+        "console_scripts": [
+            "clear_lambda_storage = clear_lambda_storage:main",
+        ]
+    }
 )


### PR DESCRIPTION
This change allows running the module as a script from the command line with
expected parameters.

Ex, after:
pip install clear_lambda_storage

The script can be run as:
python -m clear_lambda_storage --regions ap-east-1 ap-south-1

Details for how the setuptools creates this can be found here:
https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation