### PR TITLE
Fix README executable name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Install via pip
 .. code-block:: bash
 
     pip install clear-lambda-storage
-    clear-lambda-storage
+    clear_lambda_storage
 
 Install via source
 


### PR DESCRIPTION
The executable is `clear_lambda_storage`; updated README to reflect that.