### PR TITLE
fix: correct profile arg in readme example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,10 @@ Provide credentials:
     python clear_lambda_storage.py --token-key-id <access_key_id> --token-secret <secret_access_key>
 
 Alternate usage:
+
 .. code-block:: bash
 
-    python clear_lambda_storage.py --profile-id <profile_id> --num-to-keep 2
+    python clear_lambda_storage.py --profile <profile_id> --num-to-keep 2
 
 ⚡️ `Serverless Framework <https://serverless.com>`_ usage
 ----------------------------------------------------------


### PR DESCRIPTION
Just a small PR to fix the formatting of the 'alternate usage' example and correct the argument `profile-id` to `profile`.